### PR TITLE
feat: improve mobile cart and add QR code to receipt

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,11 @@
   <div id="receipt-modal" class="receipt-modal hidden">
     <div class="receipt">
       <h2>Nota Fiscal</h2>
+      <div class="receipt-header">
+        <p>CNPJ: 00.000.000/0001-00</p>
+        <p>Endereço: Rua Exemplo, 123 - São Paulo/SP</p>
+        <p>Cliente: Consumidor Final</p>
+      </div>
       <p><strong>Data:</strong> <span id="receipt-date"></span></p>
       <table id="receipt-table" class="receipt-table">
         <thead>
@@ -49,7 +54,12 @@
         <p><strong>Total de Impostos:</strong> <span id="receipt-taxes"></span></p>
         <p class="receipt-total"><strong>Total da compra:</strong> <span id="receipt-total"></span></p>
       </div>
-      <p class="disclaimer">Documento emitido por simulador educacional. Não possui validade fiscal.</p>
+        <img
+          id="qr-code"
+          class="qr-code"
+          alt="QR Code da Educação Fiscal do Paraná"
+        >
+      <p class="disclaimer">Este documento não tem valor fiscal e foi gerado com um simulador educacional.</p>
       <button id="print-btn" class="print-btn">Imprimir</button>
       <button id="close-receipt-btn" class="close-btn">Fechar</button>
     </div>

--- a/script.js
+++ b/script.js
@@ -45,6 +45,11 @@ const receiptDateEl   = document.getElementById('receipt-date');
 const receiptTotalEl  = document.getElementById('receipt-total');
 const printBtnEl      = document.getElementById('print-btn');
 const closeReceiptBtnEl = document.getElementById('close-receipt-btn');
+const qrCodeEl        = document.getElementById('qr-code');
+
+// Link base utilizado no QR Code da nota fiscal
+const qrLink = 'https://www.educacaofiscal.pr.gov.br/';
+qrCodeEl.src = `https://chart.googleapis.com/chart?chs=120x120&cht=qr&chl=${encodeURIComponent(qrLink)}`;
 
 // Formata números como moeda brasileira (R$).
 const formatCurrency = (value) => {
@@ -218,6 +223,7 @@ function printReceipt() {
     th { background-color: #f0f8ff; }
     tfoot td { font-weight: bold; }
     .disclaimer { margin-top: 1rem; font-size: 0.8rem; font-style: italic; color: #555; text-align: center; }
+    .qr-code { display:block; margin:1rem auto; }
   `;
   let html = `<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Nota Fiscal</title><style>${styles}</style></head><body>`;
   // Cabeçalho da nota
@@ -247,15 +253,17 @@ function printReceipt() {
   html += '</tbody>';
   html += `<tfoot><tr><td colspan="4">Total de impostos</td><td>${formatCurrency(totalTaxes)}</td></tr>`;
   html += `<tr><td colspan="4">Total da compra</td><td>${formatCurrency(totalPurchase)}</td></tr></tfoot></table>`;
-  html += '<p class="disclaimer">Documento emitido por simulador educacional. Não possui validade fiscal.</p>';
+  const encodedLink = encodeURIComponent(qrLink);
+  html += `<img class="qr-code" src="https://chart.googleapis.com/chart?chs=120x120&cht=qr&chl=${encodedLink}" alt="QR Code da Educação Fiscal do Paraná">`;
+  html += '<p class="disclaimer">Este documento não tem valor fiscal e foi gerado com um simulador educacional.</p>';
   html += '</body></html>';
   printWindow.document.write(html);
   printWindow.document.close();
-  printWindow.focus();
-  setTimeout(() => {
+  printWindow.onload = () => {
+    printWindow.focus();
     printWindow.print();
     printWindow.close();
-  }, 250);
+  };
 }
 
 // Esconde o modal da nota fiscal e limpa o carrinho.

--- a/style.css
+++ b/style.css
@@ -228,6 +228,15 @@ header.header p {
   text-align: center;
 }
 
+.receipt-header {
+  margin-bottom: 1rem;
+}
+
+.receipt-header p {
+  margin: 0.1rem 0;
+  font-size: 0.85rem;
+}
+
 .receipt-table {
   width: 100%;
   border-collapse: collapse;
@@ -253,10 +262,10 @@ header.header p {
 }
 
 /* Sumário da nota fiscal (totais) */
-.receipt-summary {
-  margin-top: 1rem;
-  font-size: 0.95rem;
-}
+  .receipt-summary {
+    margin-top: 1rem;
+    font-size: 0.95rem;
+  }
 .receipt-summary p {
   margin: 0.2rem 0;
   display: flex;
@@ -295,17 +304,37 @@ header.header p {
   color: #333;
 }
 
-.close-btn:hover {
-  background-color: #ccc;
-}
+  .close-btn:hover {
+    background-color: #ccc;
+  }
 
 @media (max-width: 768px) {
   .container {
     flex-direction: column;
   }
-  .cart-section {
-    position: static;
-    max-width: 100%;
-    margin-top: 1rem;
+  .product-grid {
+    padding-bottom: calc(40vh + 2rem);
   }
+  .cart-section {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    max-width: none;
+    margin-top: 0;
+    border-radius: 8px 8px 0 0;
+    box-shadow: 0 -2px 8px rgba(0,0,0,0.1);
+    max-height: 40vh;
+    overflow-y: auto;
+    z-index: 1000;
+  }
+  .cart-items {
+    max-height: 25vh;
+  }
+}
+
+/* QR code na nota fiscal */
+.qr-code {
+  display: block;
+  margin: 1rem auto;
 }


### PR DESCRIPTION
## Summary
- make mobile cart fixed and always visible
- display QR code to Paraná Educação Fiscal in receipts
- add header details to receipt for a more realistic layout
- ensure receipt prints reliably by waiting for the print window to load
- encode QR code link and adjust mobile spacing for consistent layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6890fc8100988327bfb76996ffb75e4f